### PR TITLE
readme breaks prod

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,11 +8,11 @@ Get a nice, clean badge displaying your Rails Environment or other helpful info.
 
 Add to your Gemfile:
 
-    gem "honey_badger", :group => [:development, :test, :staging]
+    gem "honey_badger"
 
 In your application layout somewhere, probably just below your body tag, render the honey_badger helper:
 
-    <%= honey_badger %>
+    <%= honey_badger unless Rails.env.production? %>
     
 If you want to display something other than the current environment name, just pass it in:
 


### PR DESCRIPTION
So, I was trying out honey_badger, and it occurred to me that it would make the app break in production. To simulate, I got the badge working in dev, then updated the Gemfile from

```
gem 'honey_badger', :group => [ :development, :qa, :beta ]
```

to

```
gem 'honey_badger', :group => [ :qa, :beta ]
```

and there was an error because the honey_badger helper wasn't defined anymore. Also, sprockets couldn't compile the css because honey_badger wasn't in the asset path, either.

So, I changed the readme to recommend including honey_badger in the default bundle, and having the layout decide whether to apply the badge.

There may be a better way to do this, which would be awesome. Also, it might be nice to make the badge still show up in the markup, but have the style hide it in production. Regardless, this seemed like the attached commit is a good change.
