### PR TITLE
Update route syntax to work with Rails 4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 HoneyBadger::Engine.routes.draw do
-  match "/" => "application#index"
+  get "/" => "application#index"
 end


### PR DESCRIPTION
I have a Rails 4 app that isn't loading with the existing syntax.
